### PR TITLE
Fix: selected option can't be distinguish in the MAC Safari

### DIFF
--- a/installer/dup-installer/assets/inc.css.php
+++ b/installer/dup-installer/assets/inc.css.php
@@ -35,7 +35,6 @@
     }
 
     select , option {
-        background-color: lightgray;
         color: black;
     }
     select {


### PR DESCRIPTION
Slack chat: https://snapcreek.slack.com/archives/C7A5VTKSB/p1567082660091600